### PR TITLE
Upgrade to Scala 2.12

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object Dependencies {
   import Resolvers._
   import Versions._
 
-  val scalaTest               =  "org.scalatest" % "scalatest_2.11" % "2.1.6" % "test"
+  val scalaTest               =  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
 }
 
@@ -31,8 +31,8 @@ object BuildSettings {
       organization := "pl.project13.scala",
       name         := "rainbow",
       version      := "0.2",
-      scalaVersion := "2.11.0",
-      crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.4", "2.11.0"),
+      scalaVersion := "2.12.8",
+      crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.4", "2.11.0", "2.12.8"),
       libraryDependencies ++= dependencies
     )
 


### PR DESCRIPTION
This PR upgrades this library to Scala 2.12 and to use ScalaTest 3.0.5.

@ktoso please could you publish the 2.12 version?